### PR TITLE
write and read at once

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -19,36 +19,94 @@ class TcpClient{
         client_socket(client_context)
         {
             asio::ip::tcp::endpoint endpoint(asio::ip::address::from_string("127.0.0.1"),8080);
-            client_socket.connect(endpoint); 
+            client_socket.connect(endpoint);
         }
 
-        void run()
+        void read()
         {
+            std::string message;
+            // int fd = client_socket.native_handle();
+            // std::cout << "Socket FD: " << fd << "\n"; // -1 means invalid
+            if (!this->client_socket.is_open())
+            {
+                std::cout<<"client socket is not open\n";
+                return;
+            }
+
             while (true)
             {
-                //write part
-                std::cout<<"client: ";
-                std::string message;
-                std::getline(std::cin, message);
-                if (this->send_message(message))
+                if (this->read_message(this->client_socket, message) )
                 {
-                    std::cout<<"error in send_message, stopped.\n";
+                    std::cout<<"error in read_message, stopping.\n";
                     break;
-                }
-                
-                //read part
-                message.clear();
-                if (this->read_message(std::ref(message)))
-                {
-                    std::cout<<"error in read_message, stopped.\n";
-                    break;
-                }
-
-                std::cout<<"server: "<<message<<std::endl;                
-            }          
+                }   
+                std::cout<<"\nserver: "<<message<<std::endl; 
+            }
         }
 
-        std::error_code send_message(std::string message)
+        void write()
+        {
+            std::string message;
+            while (true)
+            {
+                std::cout<<"Client: ";
+                std::getline(std::cin, message);
+                if (this->send_message(this->client_socket, message))
+                {
+                    std::cout<<"error in send_message, stopping.\n";
+                    break;
+                }
+            }
+        }
+
+        void run ()
+        {
+            std::thread read_thread(&TcpClient::read, this);
+            std::thread write_thread(&TcpClient::write, this);
+
+            read_thread.join();
+            write_thread.join();
+        }
+
+         std::error_code read_message(asio::ip::tcp::socket& client_socket, std::string& message)
+        {
+           
+            std::error_code r_ec;
+            std::vector<char> buffer(PREFIX_LENGTH);
+            size_t bytes_read = asio::read(client_socket, asio::buffer(buffer, buffer.size()), r_ec);
+
+            if (r_ec)
+            {
+                std::cout<<"read error: "<<r_ec.message()<<std::endl;
+                return r_ec;
+            }
+
+            // std::cout<<"bytes_read: "<<bytes_read<<std::endl;
+
+            uint32_t net_len = 0;
+            memcpy(
+                &net_len,
+                buffer.data(),
+                PREFIX_LENGTH
+            );
+
+            uint32_t buffer_len = ntohl(net_len);
+
+            message.clear();
+            message.resize(buffer_len);
+          
+            bytes_read = asio::read(client_socket, asio::buffer(message, message.length()), r_ec);
+
+            if(r_ec)
+            {
+                std::cout<<"read error: "<<r_ec.message()<<std::endl;
+                return r_ec;
+            }
+            
+            return r_ec;
+        }
+
+        std::error_code send_message(asio::ip::tcp::socket& client_socket, std::string message)
         {
             std::error_code w_ec;
             uint32_t message_len = message.length();
@@ -74,46 +132,9 @@ class TcpClient{
                 std::cout<<"write error: "<<w_ec.message()<<std::endl;
                 return w_ec;
             }
-            
+
             return w_ec;
         }
-
-        std::error_code read_message(std::string& message)
-        {
-        
-            std::error_code r_ec;
-            std::vector<char> buffer(PREFIX_LENGTH);
-            size_t bytes_read = asio::read(client_socket, asio::buffer(buffer, buffer.size()), r_ec);
-
-            if (r_ec)
-            {
-                std::cout<<"read error: "<<r_ec.message()<<std::endl;
-                return r_ec;
-            }
-
-            //std::cout<<"bytes_read: "<<bytes_read<<std::endl;
-
-            uint32_t net_len = 0;
-            memcpy(
-                &net_len,
-                buffer.data(),
-                PREFIX_LENGTH
-            );
-
-            uint32_t buffer_len = ntohl(net_len);
-            message.resize(buffer_len);
-           
-            bytes_read = asio::read(client_socket, asio::buffer(message, message.length()), r_ec);
-
-            if(r_ec)
-            {
-                std::cout<<"read error: "<<r_ec.message()<<std::endl;
-                return r_ec;
-            }
-            
-            return r_ec;
-        }
-
         
 };
 


### PR DESCRIPTION
Earlier the chat was server then client then server so each had to wait indefinitely for the other to send message before it can send message.

Solution: separate thread for write and read operation in both server
          and client. so now both can write and read at the same time.